### PR TITLE
Implemented write_f32, and some bug fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,16 +16,16 @@ pub mod log;
 pub mod sfont;
 
 pub fn is_soundfont(filename: &str) -> bool {
-    unsafe { 
-        let name = CString::new(filename).unwrap().as_ptr();
-        ffi::fluid_is_soundfont(name) != 0
+    let name = CString::new(filename).unwrap();
+    unsafe {
+        ffi::fluid_is_soundfont(name.as_ptr()) != 0
     }
 }
 
 pub fn is_midifile(filename: &str) -> bool {
+    let name = CString::new(filename).unwrap();
     unsafe { 
-        let name = CString::new(filename).unwrap().as_ptr();
-        ffi::fluid_is_midifile(name) != 0
+        ffi::fluid_is_midifile(name.as_ptr()) != 0
     }
 }
 

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -335,9 +335,9 @@ impl Player {
     }
 
     pub fn add(&self, file: &str) {
+        let file_str = CString::new(file).unwrap();
         unsafe {
-            let file_str = CString::new(file).unwrap().as_ptr();
-            fluid_player_add(self.to_raw(), file_str);
+            fluid_player_add(self.to_raw(), file_str.as_ptr());
         }
     }
 

--- a/src/ramsfont.rs
+++ b/src/ramsfont.rs
@@ -21,8 +21,9 @@ impl RAMSoundFont {
     }
 
     pub fn set_name(&self, name: &str) -> i32 {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            fluid_ramsfont_set_name(self.to_raw(), CString::new(name).unwrap().as_ptr())
+            fluid_ramsfont_set_name(self.to_raw(), name_str.as_ptr())
         }
     } 
 
@@ -70,8 +71,9 @@ impl RAMSample {
     }
 
     pub fn set_name(&self, name: &str) -> i32 {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            fluid_sample_set_name(self.to_raw(), CString::new(name).unwrap().as_ptr())
+            fluid_sample_set_name(self.to_raw(), name_str.as_ptr())
         }
     }
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -51,13 +51,11 @@ impl Sequencer {
     }
 
     pub fn register_client<T: Fn(u32, Event, Sequencer)>(&self, name: &str, callback: T) -> i16 {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            // get name
-            let name = CString::new(name).unwrap().as_ptr();
-
             let user_data = &callback as *const _ as *mut c_void;
             
-            return fluid_sequencer_register_client(self.c_fluid_sequencer, name, 
+            return fluid_sequencer_register_client(self.c_fluid_sequencer, name_str.as_ptr(), 
                                                    event_callback_wrapper::<T>, user_data) as i16
         }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,39 +32,40 @@ impl Settings {
     }
 
     pub fn get_type(&self, name: &str) -> SettingsType {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            transmute(fluid_settings_get_type(self.to_raw(), CString::new(name).unwrap().as_ptr()))
+            transmute(fluid_settings_get_type(self.to_raw(), name_str.as_ptr()))
         }
     }
 
     pub fn get_hints(&self, name: &str) -> i32 {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            fluid_settings_get_hints(self.to_raw(), CString::new(name).unwrap().as_ptr())
+            fluid_settings_get_hints(self.to_raw(), name_str.as_ptr())
         }
     }
 
     pub fn is_realtime(&self, name: &str) -> bool {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            fluid_settings_is_realtime(self.to_raw(), CString::new(name).unwrap().as_ptr()) != 0
+            fluid_settings_is_realtime(self.to_raw(), name_str.as_ptr()) != 0
         }
     }
 
     pub fn setstr(&self, name: &str, string: &str) -> bool {
+        let name_str = CString::new(name).unwrap();
+        let string_str = CString::new(string).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            let string_str = CString::new(string).unwrap().as_ptr();
-
-            fluid_settings_setstr(self.c_fluid_settings, name_str, string_str) != 0
+            fluid_settings_setstr(self.c_fluid_settings, name_str.as_ptr(), string_str.as_ptr()) != 0
         }
     }
 
     // TODO
     /*pub fn copystr(&self, name: &str, mut string: &mut String, length: i32) -> bool {
+        let name_str = CString::new(name).unwrap();
+        let string_str = CString::new(string.clone()).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            let string_str = CString::new(string.clone()).unwrap().as_ptr();
-
-            let res = fluid_settings_copystr(self.c_fluid_settings, name_str, string_str as *mut c_char, length as c_int);
+            let res = fluid_settings_copystr(self.c_fluid_settings, name_str.as_ptr(), string_str.as_ptr() as *mut c_char, length as c_int);
             *string = str::from_utf8(CStr::from_ptr(string_str).to_bytes()).unwrap().to_string();
 
             res != 0
@@ -88,8 +89,8 @@ impl Settings {
 
     pub fn getstr_default(&self, name: &str) -> Option<String> {
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            let res = fluid_settings_getstr_default(self.c_fluid_settings, name_str);
+            let name_str = CString::new(name).unwrap();
+            let res = fluid_settings_getstr_default(self.c_fluid_settings, name_str.as_ptr());
 
             if res.is_null() {
                 None
@@ -100,27 +101,25 @@ impl Settings {
     }
 
     pub fn getstr_equal(&self, name: &str, value: &str) -> bool {
+        let name_str = CString::new(name).unwrap();
+        let value_str = CString::new(value).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            let value_str = CString::new(value).unwrap().as_ptr();
-            fluid_settings_str_equal(self.to_raw(), name_str, value_str) != 0
+            fluid_settings_str_equal(self.to_raw(), name_str.as_ptr(), value_str.as_ptr()) != 0
         }
     }
 
     pub fn setnum(&self, name: &str, value: f64) -> bool {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            fluid_settings_setnum(self.c_fluid_settings, name_str, value as c_double) != 0
+            fluid_settings_setnum(self.c_fluid_settings, name_str.as_ptr(), value as c_double) != 0
         }
     }
 
     pub fn getnum(&self, name: &str) -> Option<f64> {
+        let mut value: f64 = 0.0;
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let mut value: f64 = 0.0;
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            let res = fluid_settings_getnum(self.to_raw(), name_str, &mut value);
+            let res = fluid_settings_getnum(self.to_raw(), name_str.as_ptr(), &mut value);
 
             match res {
                 1 => Some(value),
@@ -130,10 +129,9 @@ impl Settings {
     }
 
     pub fn getnum_default(&self, name: &str) -> Option<f64> {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            let res: f64 = fluid_settings_getnum_default(self.to_raw(), name_str);
+            let res: f64 = fluid_settings_getnum_default(self.to_raw(), name_str.as_ptr());
 
             match res {
                 0.0 => None,
@@ -148,30 +146,28 @@ impl Settings {
                 return None;
             }
 
-            let name_str = CString::new(name).unwrap().as_ptr();
+            let name_str = CString::new(name).unwrap();
             let mut min: f64 = 0.0;
             let mut max: f64 = 0.0;
 
-            fluid_settings_getnum_range(self.to_raw(), name_str, &mut min, &mut max);
+            fluid_settings_getnum_range(self.to_raw(), name_str.as_ptr(), &mut min, &mut max);
 
             Some((min, max))    
         }
     }
 
     pub fn setint(&self, name: &str, value: i32) -> bool {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            fluid_settings_setint(self.c_fluid_settings, name_str, value as c_int) != 0
+            fluid_settings_setint(self.c_fluid_settings, name_str.as_ptr(), value as c_int) != 0
         }
     }
 
     pub fn getint(&self, name: &str) -> Option<i32> {
+        let mut value: i32 = 0;
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let mut value: i32 = 0;
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            let res = fluid_settings_getint(self.to_raw(), name_str, &mut value);
+            let res = fluid_settings_getint(self.to_raw(), name_str.as_ptr(), &mut value);
 
             match res {
                 1 => Some(value),
@@ -181,10 +177,9 @@ impl Settings {
     }
 
     pub fn getint_default(&self, name: &str) -> Option<i32> {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            let res: i32 = fluid_settings_getint_default(self.to_raw(), name_str);
+            let res: i32 = fluid_settings_getint_default(self.to_raw(), name_str.as_ptr());
 
             match res {
                 0 => None,
@@ -199,22 +194,21 @@ impl Settings {
                 return None;
             }
 
-            let name_str = CString::new(name).unwrap().as_ptr();
+            let name_str = CString::new(name).unwrap();
             let mut min: i32 = 0;
             let mut max: i32 = 0;
 
-            fluid_settings_getint_range(self.to_raw(), name_str, &mut min, &mut max);
+            fluid_settings_getint_range(self.to_raw(), name_str.as_ptr(), &mut min, &mut max);
 
             Some((min, max))    
         }
     }
 
     pub fn foreach_option<T: Fn(&str, &str)>(&self, name: &str, callback: T) {
+        let user_data = &callback as *const _ as *mut c_void;
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let user_data = &callback as *const _ as *mut c_void;
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            fluid_settings_foreach_option(self.to_raw(), name_str, user_data, foreach_option_callback_wrapper::<T>);  
+            fluid_settings_foreach_option(self.to_raw(), name_str.as_ptr(), user_data, foreach_option_callback_wrapper::<T>);  
         }
 
         extern fn foreach_option_callback_wrapper<T>(closure: *mut c_void, name: *const c_char, option: *const c_char)
@@ -231,10 +225,9 @@ impl Settings {
     }
 
     pub fn option_count(&self, name: &str) -> Option<(i32)> {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-
-            let res = fluid_settings_option_count(self.to_raw(), name_str);
+            let res = fluid_settings_option_count(self.to_raw(), name_str.as_ptr());
 
             match res {
                 -1 => None,
@@ -244,11 +237,11 @@ impl Settings {
     }
 
     pub fn option_concat(&self, name: &str, separator: &str) -> Option<(&str)> {
-        unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            let separator_str = CString::new(separator).unwrap().as_ptr();
+        let name_str = CString::new(name).unwrap();
+        let separator_str = CString::new(separator).unwrap();
 
-            let res = fluid_settings_option_concat(self.to_raw(), name_str, separator_str);
+        unsafe {
+            let res = fluid_settings_option_concat(self.to_raw(), name_str.as_ptr(), separator_str.as_ptr());
 
             if res.is_null() {
                 None

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -189,9 +189,9 @@ impl Synth {
     }
 
     pub fn program_select_by_sfont_name(&self, chan: i32, sfont_name: &str, bank_num: u32, preset_num: u32) -> bool {
+        let sfont_name_str = CString::new(sfont_name).unwrap();
         unsafe {
-            let sfont_name_str = CString::new(sfont_name).unwrap().as_ptr();
-            fluid_synth_program_select_by_sfont_name(self.c_fluid_synth, chan as c_int, sfont_name_str, bank_num as c_uint, preset_num as c_uint) == 0
+            fluid_synth_program_select_by_sfont_name(self.c_fluid_synth, chan as c_int, sfont_name_str.as_ptr(), bank_num as c_uint, preset_num as c_uint) == 0
         }                          
     }
 
@@ -257,9 +257,9 @@ impl Synth {
     }
 
     pub fn sfload(&self, filename: &str, reset_presets: i32) -> Option <u32> {
+        let filename_str = CString::new(filename).unwrap();
         unsafe {
-            let filename_str = CString::new(filename).unwrap().as_ptr();
-            match fluid_synth_sfload(self.c_fluid_synth, filename_str, reset_presets as c_int) {
+            match fluid_synth_sfload(self.c_fluid_synth, filename_str.as_ptr(), reset_presets as c_int) {
                 -1 => None,
                 ID => Some (ID as u32),
             }
@@ -327,9 +327,9 @@ impl Synth {
     }
 
     pub fn get_sfont_by_name(&self, name: &str) -> Option<SoundFont> {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            let result = fluid_synth_get_sfont_by_name(self.to_raw(), name_str);
+            let result = fluid_synth_get_sfont_by_name(self.to_raw(), name_str.as_ptr());
 
             if result.is_null() {
                 None
@@ -514,30 +514,30 @@ impl Synth {
     }
 
     pub fn create_key_tuning(&self, bank: i32, prog: i32, name: &str, pitch: *const f64) -> bool {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            fluid_synth_create_key_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str, pitch as *const c_double) == 0
+            fluid_synth_create_key_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str.as_ptr(), pitch as *const c_double) == 0
         }
     }
 
     pub fn activate_key_tuning(&self, bank: i32, prog: i32, name: &str, pitch: *const f64, apply: bool) -> bool {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            fluid_synth_activate_key_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str, pitch as *const c_double, apply as c_int) == 0
+            fluid_synth_activate_key_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str.as_ptr(), pitch as *const c_double, apply as c_int) == 0
         }
     }
 
     pub fn create_octave_tuning(&self, bank: i32, prog: i32, name: &str, pitch: *const f64) -> bool {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            fluid_synth_create_octave_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str, pitch as *const c_double) == 0
+            fluid_synth_create_octave_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str.as_ptr(), pitch as *const c_double) == 0
         }
     }
 
     pub fn activate_octave_tuning(&self, bank: i32, prog: i32, name: &str, pitch: *const f64, apply: bool) -> bool {
+        let name_str = CString::new(name).unwrap();
         unsafe {
-            let name_str = CString::new(name).unwrap().as_ptr();
-            fluid_synth_activate_octave_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str, pitch as *const c_double, apply as c_int) == 0
+            fluid_synth_activate_octave_tuning(self.to_raw(), bank as c_int, prog as c_int, name_str.as_ptr(), pitch as *const c_double, apply as c_int) == 0
         }
     }
 

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -256,10 +256,10 @@ impl Synth {
         }
     }
 
-    pub fn sfload(&self, filename: &str, reset_presets: i32) -> bool {
+    pub fn sfload(&self, filename: &str, reset_presets: i32) -> u32 {
         unsafe {
             let filename_str = CString::new(filename).unwrap().as_ptr();
-            fluid_synth_sfload(self.c_fluid_synth, filename_str, reset_presets as c_int) == 0
+            fluid_synth_sfload(self.c_fluid_synth, filename_str, reset_presets as c_int)
         }                    
     }
 

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -256,10 +256,13 @@ impl Synth {
         }
     }
 
-    pub fn sfload(&self, filename: &str, reset_presets: i32) -> u32 {
+    pub fn sfload(&self, filename: &str, reset_presets: i32) -> Option <u32> {
         unsafe {
             let filename_str = CString::new(filename).unwrap().as_ptr();
-            fluid_synth_sfload(self.c_fluid_synth, filename_str, reset_presets as c_int)
+            match fluid_synth_sfload(self.c_fluid_synth, filename_str, reset_presets as c_int) {
+                -1 => None,
+                ID => Some (ID as u32),
+            }
         }                    
     }
 


### PR DESCRIPTION
While using rust-fluidsynth for my project [Codecophony](https://github.com/elidupree/codecophony), I ran into a few improvements I needed.

* `sfload` now returns the soundfont id so that it can be used.
* A bunch of `CString`s had their lifetimes end before they were used, resulting in segfaults.
* Implemented an interface for `write_f32` that writes into a pair of `&mut Vec<f32>`.

(The other most obvious use case for fluidsynth's `write_f32` is writing interleaved data into a single buffer. Perhaps we could provide a separate function `write_f32_interleaved (&self, usize, &mut Vec<f32>)` for that purpose.)